### PR TITLE
Store job namespace in model and use in FetchAllocations (#21)

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ type model struct {
 	logsPage        page.Model
 	loglinePage     page.Model
 	jobID           string
+	jobNamespace    string
 	allocID         string
 	taskName        string
 	logline         string
@@ -95,7 +96,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if selectedPageRow, err := m.getCurrentPageModel().GetSelectedPageRow(); err == nil {
 					switch m.currentPage {
 					case nomad.JobsPage:
-						m.jobID = nomad.JobIDFromKey(selectedPageRow.Key)
+						m.jobID, m.jobNamespace = nomad.JobIDAndNamespaceFromKey(selectedPageRow.Key)
 					case nomad.AllocationsPage:
 						m.allocID, m.taskName = nomad.AllocIDAndTaskNameFromKey(selectedPageRow.Key)
 					case nomad.LogsPage:
@@ -129,7 +130,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if selectedPageRow, err := m.getCurrentPageModel().GetSelectedPageRow(); err == nil {
 					switch m.currentPage {
 					case nomad.JobsPage:
-						m.jobID = nomad.JobIDFromKey(selectedPageRow.Key)
+						m.jobID, m.jobNamespace = nomad.JobIDAndNamespaceFromKey(selectedPageRow.Key)
 						m.setPage(nomad.JobSpecPage)
 						return m, m.getCurrentPageCmd()
 					case nomad.AllocationsPage:
@@ -282,7 +283,7 @@ func (m *model) getCurrentPageCmd() tea.Cmd {
 	case nomad.JobSpecPage:
 		return nomad.FetchJobSpec(m.nomadUrl, m.nomadToken, m.jobID)
 	case nomad.AllocationsPage:
-		return nomad.FetchAllocations(m.nomadUrl, m.nomadToken, m.jobID)
+		return nomad.FetchAllocations(m.nomadUrl, m.nomadToken, m.jobID, m.jobNamespace)
 	case nomad.AllocSpecPage:
 		return nomad.FetchAllocSpec(m.nomadUrl, m.nomadToken, m.allocID)
 	case nomad.LogsPage:

--- a/nomad/allocations.go
+++ b/nomad/allocations.go
@@ -76,10 +76,13 @@ type allocationRowEntry struct {
 	StartedAt, FinishedAt                time.Time
 }
 
-func FetchAllocations(url, token, jobID string) tea.Cmd {
+func FetchAllocations(url, token, jobID, jobNamespace string) tea.Cmd {
 	return func() tea.Msg {
+		params := map[string]string{
+			"namespace": jobNamespace,
+		}
 		fullPath := fmt.Sprintf("%s%s%s%s", url, "/v1/job/", jobID, "/allocations")
-		body, err := get(fullPath, token, nil)
+		body, err := get(fullPath, token, params)
 		if err != nil {
 			return message.ErrMsg{Err: err}
 		}

--- a/nomad/jobs.go
+++ b/nomad/jobs.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"sort"
 	"strconv"
+	"strings"
 	"wander/components/page"
 	"wander/formatter"
 	"wander/message"
@@ -109,9 +110,11 @@ func jobResponsesAsTable(jobResponse []jobResponseEntry) ([]string, []page.Row) 
 }
 
 func toJobsKey(jobResponseEntry jobResponseEntry) string {
-	return jobResponseEntry.ID
+	return jobResponseEntry.ID + " " + jobResponseEntry.Namespace
 }
 
-func JobIDFromKey(key string) string {
-	return key
+func JobIDAndNamespaceFromKey(key string) (string, string) {
+	split := strings.Split(key, " ")
+	return split[0], split[1]
+
 }


### PR DESCRIPTION
Adds namespaces to the `v1/:job_id/allocations` API requests.  I stored the namespace in the key, similar to what you did with allocation's `allocID` and `taskName`.