### PR TITLE
Fix panic on unset commitSHA

### DIFF
--- a/internal/tui/components/app/app.go
+++ b/internal/tui/components/app/app.go
@@ -572,5 +572,9 @@ func getVersionString(v, s string) string {
 	if v == "" {
 		return constants.NoVersionString
 	}
-	return fmt.Sprintf("%s (%s)", v, s[:7])
+	if len(s) >= 7 {
+		s = s[:7]
+	}
+
+	return fmt.Sprintf("%s (%s)", v, s)
 }


### PR DESCRIPTION
If built with a `Version` number but not `commitSHA`, the application would compile but throw a panic on startup. Not sure how you want to handle this, or mark this is unsupported.

I hit this trying to update the package for nixos, where getting commitHash is really hard since the versions are built from release tarballs.
