### PR TITLE
Improve configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,108 +76,109 @@ Run the app by running `wander` in a terminal. See `wander --help` and config se
 
 Priority in order of highest to lowest is command line arguments, then environment variables, then the config file.
 
-Example yaml file showing all options (uncomment an option to enable it):
+Example yaml file showing all options (copy this into `$HOME/.wander.yaml` and uncomment/edit as desired):
 
-```shell
+```yaml
 # Nomad address. Default "http://localhost:4646"
-#nomad_addr: http://localhost:4646
+#nomad_addr: "http://localhost:4646"
 
 # Nomad token
-#nomad_token: my-token
+#nomad_token: ""
 
 # Nomad region
-#nomad_region: west
+#nomad_region: ""
 
 # Nomad namespace. Default "*"
-#nomad_namespace: "my-namespace"
+#nomad_namespace: "*"
 
 # Nomad http auth, in the form of "user" or "user:pass"
-#nomad_http_auth: "username:password"
+#nomad_http_auth: ""
 
 # Path to a PEM encoded CA cert file to use to verify the Nomad server SSL certificate
-#nomad_cacert: "/path/to/cert"
+#nomad_cacert: ""
 
 # Path to a directory of PEM encoded CA cert files to verify the Nomad server SSL certificate. If both cacert and capath are specified, cacert is used
-#nomad_capath: "/path/to/cert/directory"
+#nomad_capath: ""
 
 # Path to a PEM encoded client cert for TLS authentication to the Nomad server. Must also specify client key
-#nomad_client_cert: "/path/to/cert"
+#nomad_client_cert: ""
 
 # Path to an unencrypted PEM encoded private key matching the client cert
-#nomad_client_key: "/path/to/key"
+#nomad_client_key: ""
 
 # The server name to use as the SNI host when connecting via TLS
-#nomad_tls_server_name: server-name
+#nomad_tls_server_name: ""
 
-# If true, do not verify TLS certificates. Default false
-#nomad_skip_verify: true
+# If True, do not verify TLS certificates. Default False
+#nomad_skip_verify: False
 
 # Seconds between updates for job & allocation pages. Disable with -1. Default 2
-#wander_update_seconds: 1
+#wander_update_seconds: 2
 
-# Columns to display for Jobs view - can reference Meta keys. Default "ID,Type,Namespace,Status,Count,Submitted,Since Submit"
-#wander_job_columns: "Job,Type,Namespace,Priority,Status,Count,Submitted,Since Submit,SomeMetaKey"
+# Columns to display for Jobs view - can reference Meta keys. Default "Job,Type,Namespace,Status,Count,Submitted,Since Submit"
+#wander_job_columns: "Job,Type,Namespace,Status,Count,Submitted,Since Submit"
 
 # Columns to display for Tasks for Job view. Default "Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"
-#wander_tasks_for_job_columns: "Job,Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"
+#wander_tasks_for_job_columns: "Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"
 
 # Columns to display for All Tasks view. Default "Job,Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"
 #wander_all_tasks_columns: "Job,Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"
 
-# If true, start with compact header. Default false
-#wander_compact_header: true
+# If True, start with compact header. Default False
+#wander_compact_header: False
 
-# If true, start in All Tasks view. Default false
-#wander_start_all_tasks: true
+# If True, start in All Tasks view. Default False
+#wander_start_all_tasks: False
 
-# If true, remove unnecessary gaps between table columns when possible. Default true
-# If you want column positions to remain static as you scroll and filter, set this to false
-#wander_compact_tables: true
+# If True, remove unnecessary gaps between table columns when possible. Default True
+# If you want column positions to remain static as you scroll and filter, set this to False
+#wander_compact_tables: True
 
 # Log byte offset from which logs start. Default 1000000
 #wander_log_offset: 1000000
 
-# If true, follow new logs as they come in rather than having to reload. Default true
-#wander_log_tail: true
+# If True, follow new logs as they come in rather than having to reload. Default True
+#wander_log_tail: True
 
-# If true, copy the full path to file after save. Default false
-#wander_copy_save_path: true
+# If True, copy the full path to file after save. Default False
+#wander_copy_save_path: False
 
 # Topics to follow in event streams, comma-separated. Default "Job,Allocation,Deployment,Evaluation"
 # see https://www.nomadproject.io/api-docs/events#event-stream
-#wander_event_topics: Job:my-job,Job:my-other-job,Allocation:my-job,Evaluation,Deployment:*
+#wander_event_topics: "Job,Allocation,Deployment,Evaluation"
 
 # Namespace used in stream for all events. "*" for all namespaces. Default "default"
-#wander_event_namespace: "*" # * needs surrounding "" in yaml
+#wander_event_namespace: "default"
 
-# jq (https://stedolan.github.io/jq/) query used for parsing events. "." to show entire event JSON. Default is:
-# wander_event_jq_query: >
-#   .Events[] | {
-#      "1:Index": .Index,
-#      "2:Topic": .Topic,
-#      "3:Type": .Type,
-#      "4:Name": .Payload | (.Job // .Allocation // .Deployment // .Evaluation) | (.JobID // .ID),
-#      "5:ID": .Payload | (.Job.ID // (.Allocation // .Deployment // .Evaluation).ID[:8])
-#   }
+# The jq (https://stedolan.github.io/jq/) query used for parsing events. "." to show entire event JSON. Default is:
+#  .Events[] | {
+#     "1:Index": .Index,
+#     "2:Topic": .Topic,
+#     "3:Type": .Type,
+#     "4:Name": .Payload | (.Job // .Allocation // .Deployment // .Evaluation) | (.JobID // .ID),
+#     "5:ID": .Payload | (.Job.ID // (.Allocation // .Deployment // .Evaluation).ID[:8])
+#  }
 # The numbering exists to preserve ordering, as https://github.com/itchyny/gojq does not keep the order of object keys
-#wander_event_jq_query: .
+#wander_event_jq_query: >
+#  .Events[] | {
+#     "1:Index": .Index,
+#     "2:Topic": .Topic,
+#     "3:Type": .Type,
+#     "4:Name": .Payload | (.Job // .Allocation // .Deployment // .Evaluation) | (.JobID // .ID),
+#     "5:ID": .Payload | (.Job.ID // (.Allocation // .Deployment // .Evaluation).ID[:8])
+#  }
 
 # For `wander serve`. Hostname of the machine hosting the ssh server. Default "localhost"
-#wander_host: localhost
+#wander_host: "localhost"
 
 # For `wander serve`. Port for the ssh server. Default 21324
 #wander_port: 21324
 
-# For `wander serve`. Host key path for wander ssh server. Default none, i.e. ""
-#wander_host_key_path: .ssh/term_info_ed25519
+# For `wander serve`. Host key path for wander ssh server
+#wander_host_key_path: ""
 
-# For `wander serve`. Host key PEM block for wander ssh server. Default none, i.e. ""
-#wander_host_key_pem: |
-#    -----BEGIN OPENSSH PRIVATE KEY-----
-#    b3BlbnNzaD1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAACFwAAAAdzc2gtcm
-#    ...
-#    XBMuWaiQMCZjAwAAAAp3YW5kZXItc3NoAQIEBAUGBw==
-#    -----END OPENSSH PRIVATE KEY-----
+# For `wander serve`. Host key PEM block for wander ssh server
+#wander_host_key_pem: ""
 
 # Custom colors
 #wander_logo_color: "#DBBD70"

--- a/README.md
+++ b/README.md
@@ -82,37 +82,37 @@ Example yaml file showing all options (uncomment an option to enable it):
 # Nomad address. Default "http://localhost:4646"
 #nomad_addr: http://localhost:4646
 
-# Nomad token. Default ""
+# Nomad token
 #nomad_token: my-token
 
-# Nomad region. Default ""
+# Nomad region
 #nomad_region: west
 
 # Nomad namespace. Default "*"
 #nomad_namespace: "my-namespace"
 
-# Nomad http auth, in the form of "user" or "user:pass". Default ""
+# Nomad http auth, in the form of "user" or "user:pass"
 #nomad_http_auth: "username:password"
 
-# Path to a PEM encoded CA cert file to use to verify the Nomad server SSL certificate. Default ""
+# Path to a PEM encoded CA cert file to use to verify the Nomad server SSL certificate
 #nomad_cacert: "/path/to/cert"
 
-# Path to a directory of PEM encoded CA cert files to verify the Nomad server SSL certificate. If both cacert and capath are specified, cacert is used. Default ""
+# Path to a directory of PEM encoded CA cert files to verify the Nomad server SSL certificate. If both cacert and capath are specified, cacert is used
 #nomad_capath: "/path/to/cert/directory"
 
-# Path to a PEM encoded client cert for TLS authentication to the Nomad server. Must also specify client key. Default ""
+# Path to a PEM encoded client cert for TLS authentication to the Nomad server. Must also specify client key
 #nomad_client_cert: "/path/to/cert"
 
-# Path to an unencrypted PEM encoded private key matching the client cert. Default ""
+# Path to an unencrypted PEM encoded private key matching the client cert
 #nomad_client_key: "/path/to/key"
 
-# The server name to use as the SNI host when connecting via TLS. Default ""
+# The server name to use as the SNI host when connecting via TLS
 #nomad_tls_server_name: server-name
 
-# If "true", do not verify TLS certificates. Default "false"
+# If true, do not verify TLS certificates. Default false
 #nomad_skip_verify: true
 
-# Seconds between updates for job & allocation pages. Disable with "-1". Default "2"
+# Seconds between updates for job & allocation pages. Disable with -1. Default 2
 #wander_update_seconds: 1
 
 # Columns to display for Jobs view - can reference Meta keys. Default "ID,Type,Namespace,Status,Count,Submitted,Since Submit"
@@ -124,23 +124,23 @@ Example yaml file showing all options (uncomment an option to enable it):
 # Columns to display for All Tasks view. Default "Job,Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"
 #wander_all_tasks_columns: "Job,Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"
 
-# If "true", start with compact header. Default "false"
+# If true, start with compact header. Default false
 #wander_compact_header: true
 
-# If "true", start in All Tasks view. Default "false"
+# If true, start in All Tasks view. Default false
 #wander_start_all_tasks: true
 
-# If "true", remove unnecessary gaps between table columns when possible. Default "true"
+# If true, remove unnecessary gaps between table columns when possible. Default true
 # If you want column positions to remain static as you scroll and filter, set this to false
 #wander_compact_tables: true
 
-# Log byte offset from which logs start. Default "1000000"
+# Log byte offset from which logs start. Default 1000000
 #wander_log_offset: 1000000
 
-# Follow new logs as they come in rather than having to reload. Default "true"
+# If true, follow new logs as they come in rather than having to reload. Default true
 #wander_log_tail: true
 
-# If "true", copy the full path to file after save. Default "false"
+# If true, copy the full path to file after save. Default false
 #wander_copy_save_path: true
 
 # Topics to follow in event streams, comma-separated. Default "Job,Allocation,Deployment,Evaluation"
@@ -165,7 +165,7 @@ Example yaml file showing all options (uncomment an option to enable it):
 # For `wander serve`. Hostname of the machine hosting the ssh server. Default "localhost"
 #wander_host: localhost
 
-# For `wander serve`. Port for the ssh server. Default "21324"
+# For `wander serve`. Port for the ssh server. Default 21324
 #wander_port: 21324
 
 # For `wander serve`. Host key path for wander ssh server. Default none, i.e. ""

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/robinovitch61/wander/internal/dev"
+	"github.com/robinovitch61/wander/internal/tui/constants"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -74,7 +75,7 @@ var (
 		},
 		"skip-verify": {
 			cfgFileEnvVar: "nomad_skip_verify",
-			description:   `If true, do not verify TLS certificates. Default false`,
+			description:   `Do not verify TLS certificates`,
 			isBool:        true,
 			defaultIfBool: false,
 		},
@@ -87,67 +88,73 @@ var (
 		},
 		"job-columns": {
 			cfgFileEnvVar: "wander_job_columns",
-			description:   `Columns to display for Jobs view - can reference Meta keys. Default "Job,Type,Namespace,Status,Count,Submitted,Since Submit"`,
+			description:   `Columns to display for Jobs view - can reference Meta keys`,
+			defaultString: "Job,Type,Namespace,Status,Count,Submitted,Since Submit",
 		},
 		"all-tasks-columns": {
 			cfgFileEnvVar: "wander_all_tasks_columns",
-			description:   `Columns to display for All Tasks view. Default "Job,Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"`,
+			description:   `Columns to display for All Tasks view`,
+			defaultString: "Job,Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime",
 		},
 		"tasks-for-job-columns": {
 			cfgFileEnvVar: "wander_tasks_for_job_columns",
-			description:   `Columns to display for Tasks for Job view. Default "Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime"`,
+			description:   `Columns to display for Tasks for Job view`,
+			defaultString: "Alloc ID,Task Group,Alloc Name,Task Name,State,Started,Finished,Uptime",
 		},
 		"log-offset": {
 			cliShort:      "o",
 			cfgFileEnvVar: "wander_log_offset",
-			description:   `Log byte offset from which logs start. Default 1000000`,
+			description:   `Log byte offset from which logs start`,
 			isInt:         true,
 			defaultIfInt:  1000000,
 		},
 		"log-tail": {
 			cliShort:      "f",
 			cfgFileEnvVar: "wander_log_tail",
-			description:   `If true, follow new logs as they come in rather than having to reload. Default true`,
+			description:   `Follow new logs as they come in rather than having to reload`,
 			isBool:        true,
 			defaultIfBool: true,
 		},
 		"copy-save-path": {
 			cliShort:      "s",
 			cfgFileEnvVar: "wander_copy_save_path",
-			description:   `If true, copy the full path to file after save. Default false`,
+			description:   `Copy the full path to file after save`,
 			isBool:        true,
 			defaultIfBool: false,
 		},
 		"event-topics": {
 			cfgFileEnvVar: "wander_event_topics",
-			description:   `Topics to follow in event streams, comma-separated. Default "Job,Allocation,Deployment,Evaluation"`,
+			description:   `Topics to follow in event streams, comma-separated`,
+			defaultString: "Job,Allocation,Deployment,Evaluation",
 		},
 		"event-namespace": {
 			cfgFileEnvVar: "wander_event_namespace",
-			description:   `Namespace used in stream for all events. "*" for all namespaces. Default "default"`,
+			description:   `Namespace used in stream for all events. "*" for all namespaces`,
+			defaultString: "default",
 		},
 		"event-jq-query": {
 			cfgFileEnvVar: "wander_event_jq_query",
-			description:   `jq query for events. "." for entire JSON. Default shown at https://github.com/robinovitch61/wander`,
+			description:   `jq query for events. "." for entire JSON`,
+			defaultString: constants.DefaultEventJQQuery,
 		},
 		"logo-color": {
 			cfgFileEnvVar: "wander_logo_color",
 		},
 		"compact-header": {
 			cfgFileEnvVar: "wander_compact_header",
-			description:   `If true, start with compact header. Default false`,
+			description:   `Start with compact header`,
 			isBool:        true,
 			defaultIfBool: false,
 		},
 		"start-all-tasks": {
 			cfgFileEnvVar: "wander_start_all_tasks",
-			description:   `If true, start in All Tasks view. Default false`,
+			description:   `Start in All Tasks view`,
 			isBool:        true,
 			defaultIfBool: false,
 		},
 		"compact-tables": {
 			cfgFileEnvVar: "wander_compact_tables",
-			description:   `If true, remove unnecessary gaps between table columns when possible. Default true`,
+			description:   `Remove unnecessary gaps between table columns when possible`,
 			isBool:        true,
 			defaultIfBool: true,
 		},
@@ -245,7 +252,7 @@ func init() {
 }
 
 func initConfig(cmd *cobra.Command, nameToArg map[string]arg) error {
-	cfgFile := cmd.Flag("config").Value.String()
+	cfgFile := cmd.Flags().Lookup("config").Value.String()
 	if cfgFile != "" {
 		// Use config file from the flag
 		_, err := os.Stat(cfgFile)
@@ -295,9 +302,6 @@ func bindFlags(cmd *cobra.Command, nameToArg map[string]arg) {
 		// Determine the naming convention of the flags when represented in the config file
 		cliLong := f.Name
 		viperName := nameToArg[cliLong].cfgFileEnvVar
-
-		// TODO LEO: remove
-		dev.Debug(fmt.Sprintf("cliLong: %s, viperName: %s, changed: %t, isSet: %t", cliLong, viperName, f.Changed, v.IsSet(cliLong)))
 
 		// Apply the viper config value to the flag when the flag is not manually specified
 		// and viper has a value from the config file or env var

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,7 +12,6 @@ import (
 
 type arg struct {
 	cliShort, cliLong, cfgFileEnvVar, description string
-	isBool, defaultIfBool                         bool
 }
 
 var (
@@ -158,8 +157,6 @@ var (
 	}
 	startCompactArg = arg{
 		cliLong:       "compact-header",
-		isBool:        true,
-		defaultIfBool: false,
 		cfgFileEnvVar: "wander_compact_header",
 		description:   `If "true", start with compact header. Default "false"`,
 	}
@@ -225,11 +222,7 @@ func init() {
 		startAllTasksView,
 		compactTablesArg,
 	} {
-		if c.isBool {
-			rootCmd.PersistentFlags().BoolP(c.cliLong, c.cliShort, c.defaultIfBool, c.description)
-		} else {
-			rootCmd.PersistentFlags().StringP(c.cliLong, c.cliShort, "", c.description)
-		}
+		rootCmd.PersistentFlags().StringP(c.cliLong, c.cliShort, "", c.description)
 		viper.BindPFlag(c.cliLong, rootCmd.PersistentFlags().Lookup(c.cfgFileEnvVar))
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 type arg struct {
 	cliShort, cliLong, cfgFileEnvVar, description string
+	isBool, defaultIfBool                         bool
 }
 
 var (
@@ -157,6 +158,8 @@ var (
 	}
 	startCompactArg = arg{
 		cliLong:       "compact-header",
+		isBool:        true,
+		defaultIfBool: false,
 		cfgFileEnvVar: "wander_compact_header",
 		description:   `If "true", start with compact header. Default "false"`,
 	}
@@ -222,7 +225,11 @@ func init() {
 		startAllTasksView,
 		compactTablesArg,
 	} {
-		rootCmd.PersistentFlags().StringP(c.cliLong, c.cliShort, "", c.description)
+		if c.isBool {
+			rootCmd.PersistentFlags().BoolP(c.cliLong, c.cliShort, c.defaultIfBool, c.description)
+		} else {
+			rootCmd.PersistentFlags().StringP(c.cliLong, c.cliShort, "", c.description)
+		}
 		viper.BindPFlag(c.cliLong, rootCmd.PersistentFlags().Lookup(c.cfgFileEnvVar))
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -289,7 +289,7 @@ func initConfig(cmd *cobra.Command, nameToArg map[string]arg) error {
 		}
 	}
 
-	// bind viper to env vars
+	// bind viper to env vars, will prioritize env vars over config file
 	viper.AutomaticEnv()
 
 	bindFlags(cmd, nameToArg)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -22,24 +22,25 @@ var (
 		"host": {
 			cliShort:      "h",
 			cfgFileEnvVar: "wander_host",
-			description:   `Host for wander ssh server. Default "localhost"`,
+			description:   `Host for wander ssh server`,
+			defaultString: "localhost",
 		},
 		"port": {
 			cliShort:      "p",
 			cfgFileEnvVar: "wander_port",
-			description:   `Port for wander ssh server. Default 21324`,
+			description:   `Port for wander ssh server`,
 			isInt:         true,
 			defaultIfInt:  21324,
 		},
 		"host-key-path": {
 			cliShort:      "k",
 			cfgFileEnvVar: "wander_host_key_path",
-			description:   `Host key path for wander ssh server. Default none, i.e. ""`,
+			description:   `Host key path for wander ssh server`,
 		},
 		"host-key-pem": {
 			cliShort:      "m",
 			cfgFileEnvVar: "wander_host_key_pem",
-			description:   `Host key PEM block for wander ssh server. Default none, i.e. ""`,
+			description:   `Host key PEM block for wander ssh server`,
 		},
 	}
 
@@ -57,15 +58,15 @@ var (
 )
 
 func serveEntrypoint(cmd *cobra.Command, args []string) {
-	host := retrieveWithDefault(cmd, "host", serveNameToArg, "localhost")
-	portStr := retrieveWithDefault(cmd, "port", serveNameToArg, "21324")
+	host := cmd.Flags().Lookup("host").Value.String()
+	portStr := cmd.Flags().Lookup("port").Value.String()
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
 		fmt.Println(fmt.Errorf("could not convert %s to integer", portStr))
 		os.Exit(1)
 	}
-	hostKeyPath := retrieveWithDefault(cmd, "host-key-path", serveNameToArg, "")
-	hostKeyPEM := retrieveWithDefault(cmd, "host-key-pem", serveNameToArg, "")
+	hostKeyPath := cmd.Flags().Lookup("host-key-path").Value.String()
+	hostKeyPEM := cmd.Flags().Lookup("host-key-pem").Value.String()
 
 	options := []ssh.Option{wish.WithAddress(fmt.Sprintf("%s:%d", host, port))}
 	if hostKeyPath != "" {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -49,12 +49,8 @@ func trueIfTrue(v string) bool {
 	return false
 }
 
-func retrieveNonCLIWithDefault(a arg, defaultVal string) string {
-	val := viper.GetString(a.cfgFileEnvVar)
-	if val == "" {
-		return defaultVal
-	}
-	return val
+func retrieveLogoColor() string {
+	return viper.GetString(rootNameToArg["logo-color"].cfgFileEnvVar)
 }
 
 func retrieveAddress(cmd *cobra.Command) string {
@@ -63,8 +59,7 @@ func retrieveAddress(cmd *cobra.Command) string {
 
 func retrieveToken(cmd *cobra.Command) string {
 	val := cmd.Flags().Lookup("token").Value.String()
-	err := validateToken(val)
-	if err != nil {
+	if err := validateToken(val); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
 	}
@@ -270,8 +265,7 @@ func setup(cmd *cobra.Command, overrideToken string) (app.Model, []tea.ProgramOp
 	nomadAddr := retrieveAddress(cmd)
 	nomadToken := retrieveToken(cmd)
 	if overrideToken != "" {
-		err := validateToken(overrideToken)
-		if err != nil {
+		if err := validateToken(overrideToken); err != nil {
 			fmt.Println(err.Error())
 		}
 		nomadToken = overrideToken
@@ -295,7 +289,7 @@ func setup(cmd *cobra.Command, overrideToken string) (app.Model, []tea.ProgramOp
 	jobColumns := retrieveJobColumns(cmd)
 	allTaskColumns := retrieveAllTaskColumns(cmd)
 	jobTaskColumns := retrieveJobTaskColumns(cmd)
-	logoColor := retrieveNonCLIWithDefault(rootNameToArg["logo-color"], "")
+	logoColor := retrieveLogoColor()
 	startCompact := retrieveStartCompact(cmd)
 	startAllTasksView := retrieveStartAllTasksView(cmd)
 	compactTables := retrieveCompactTables(cmd)

--- a/internal/tui/constants/constants.go
+++ b/internal/tui/constants/constants.go
@@ -35,4 +35,5 @@ var TasksTableStatusStyles = JobsTableStatusStyles
 
 const DefaultPageInput = "/bin/sh"
 
+// DefaultEventJQQuery is a single line as this shows up verbatim in `wander --help`
 const DefaultEventJQQuery = `.Events[] | {"1:Index": .Index, "2:Topic": .Topic, "3:Type": .Type, "4:Name": .Payload | (.Job // .Allocation // .Deployment // .Evaluation) | (.JobID // .ID), "5:ID": .Payload | (.Job.ID // (.Allocation // .Deployment // .Evaluation).ID[:8])}`

--- a/internal/tui/constants/constants.go
+++ b/internal/tui/constants/constants.go
@@ -35,10 +35,4 @@ var TasksTableStatusStyles = JobsTableStatusStyles
 
 const DefaultPageInput = "/bin/sh"
 
-const DefaultEventJQQuery = `.Events[] | {
-	"1:Index": .Index,
-	"2:Topic": .Topic,
-	"3:Type": .Type,
-	"4:Name": .Payload | (.Job // .Allocation // .Deployment // .Evaluation) | (.JobID // .ID),
-	"5:ID": .Payload | (.Job.ID // (.Allocation // .Deployment // .Evaluation).ID[:8])
-}`
+const DefaultEventJQQuery = `.Events[] | {"1:Index": .Index, "2:Topic": .Topic, "3:Type": .Type, "4:Name": .Payload | (.Job // .Allocation // .Deployment // .Evaluation) | (.JobID // .ID), "5:ID": .Payload | (.Job.ID // (.Allocation // .Deployment // .Evaluation).ID[:8])}`


### PR DESCRIPTION
Improvements:
- make relevant options boolean flags rather than true/false strings
- make relevant options ints rather than strings
- simplify implementation of cobra + viper cli > env var > config file > default val priority
- better example `~/.wander.yaml` in README

Breaking changes:
- fully remove `wander_addr` and `wander_token` options, replacing with `nomad_addr` and `nomad_token`
- cli option boolean usage like `--compact-header true` must be replaced with `--compact-header=true` or just `--compact-header`