### PR TITLE
[nix] Add flake support to wander

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ brew install robinovitch61/tap/wander
 brew update && brew upgrade wander
 ```
 
+### > Run with Nix `flakes`
+
+Ensure [flake support is enabled](https://nixos.wiki/wiki/Flakes#Enable_flakes_temporarily)
+
+``` shell
+nix run "github:robinovitch61/wander"
+```
+
 ### > Install from NUR
 
 Ensure [NUR is accessible](https://github.com/nix-community/NUR), then run (for example):

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701301110,
+        "narHash": "sha256-Whywe9lLv3aTttK2tI4Kvw8R6mjtxseY/uiYlOQ9cPU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fadbca63cb6e17913983927b018ad4bd478f99e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "Wander";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        packages.default = self.packages.${system}.wander;
+
+        packages.wander = pkgs.buildGoModule {
+          name = "wander";
+          vendorHash = "sha256-SqDGXV8MpvEQFAkcE1NWvWjdzYsvbO5vA6k+hpY0js0=";
+          src = ./.;
+
+          nativeBuildInputs = [ pkgs.installShellFiles ];
+
+          postInstall = ''
+            installShellCompletion --cmd wander \
+               --fish <($out/bin/wander completion fish) \
+               --bash <($out/bin/wander completion bash) \
+               --zsh <($out/bin/wander completion zsh)
+          '';
+        };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Wander";
+  description = "wander: a terminal app/TUI for HashiCorp Nomad";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";


### PR DESCRIPTION
This commit lets flake users import wander package directly from the repo, as well as quickly run wander with

```
nix run "github:robinovitch61/wander"
```
